### PR TITLE
EmptyReasons: Display a generic message when there are no benefit updates

### DIFF
--- a/app/uk/gov/hmrc/tai/service/yourTaxFreeAmount/TaxCodeChangeReasonsService.scala
+++ b/app/uk/gov/hmrc/tai/service/yourTaxFreeAmount/TaxCodeChangeReasonsService.scala
@@ -37,6 +37,8 @@ class TaxCodeChangeReasonsService @Inject()(iabdTaxCodeChangeReasons: IabdTaxCod
 
     val genericReasonsForTaxCodeChange = reasons filter (_ == genericTaxCodeReasonMessage)
     val maxReasonsAllowed = 4
-    genericReasonsForTaxCodeChange.nonEmpty || reasons.size > maxReasonsAllowed
+
+    genericReasonsForTaxCodeChange.nonEmpty ||
+      (reasons.size > maxReasonsAllowed || reasons.isEmpty)
   }
 }

--- a/test/uk/gov/hmrc/tai/service/yourTaxFreeAmount/TaxCodeChangeReasonsServiceSpec.scala
+++ b/test/uk/gov/hmrc/tai/service/yourTaxFreeAmount/TaxCodeChangeReasonsServiceSpec.scala
@@ -72,6 +72,10 @@ class TaxCodeChangeReasonsServiceSpec extends PlaySpec with MockitoSugar with Fa
     }
 
     "be true" when {
+      "there are zero reasons" in {
+        service.isAGenericReason(Seq.empty) mustBe true
+      }
+
       "there are more than 4 reasons" in {
         val reasons = Seq("reason 1", "reason 2", "reason 3", "reason 4", "reason 5")
         service.isAGenericReason(reasons) mustBe true


### PR DESCRIPTION
- [x] Unit tests passing
- [x] Coverage reached
- [ ] Acceptance tests passing
- [ ] Reviewed
