### PR TITLE
ST-435-Payslip-Content-Change: Fixed dates to correspond to prototype

### DIFF
--- a/app/views/incomes/bonusPaymentAmount.scala.html
+++ b/app/views/incomes/bonusPaymentAmount.scala.html
@@ -30,7 +30,7 @@ templateRenderer: uk.gov.hmrc.renderer.TemplateRenderer, partialRetriever: uk.go
         formForErrorSummary = Some(bonusOvertimeAmountForm),
         displayBackLink = true,
         backLinkGaEventAction = Some(gaEventActionString),
-        mainHeadingText = messages("tai.bonusPaymentsAmount.title",TaxYearRangeUtil.currentTaxYearRangeSingleLine),
+        mainHeadingText = messages("tai.bonusPaymentsAmount.title",TaxYearRangeUtil.currentTaxYearRangeSingleLineBetweenDelimited),
         preHeadingText = Messages("tai.bonusPaymentsAmount.preHeading", employerName)
     )
 }

--- a/app/views/incomes/bonusPayments.scala.html
+++ b/app/views/incomes/bonusPayments.scala.html
@@ -31,7 +31,7 @@ templateRenderer: uk.gov.hmrc.renderer.TemplateRenderer, partialRetriever: uk.go
         formForErrorSummary = Some(yesNoForm),
         displayBackLink = true,
         backLinkGaEventAction = Some(gaEventActionString),
-        mainHeadingText = messages("tai.bonusPayments.title", TaxYearRangeUtil.currentTaxYearRangeSingleLine),
+        mainHeadingText = messages("tai.bonusPayments.title", TaxYearRangeUtil.currentTaxYearRangeSingleLineBetweenDelimited),
         preHeadingText = messages("tai.bonusPayments.preHeading", employerName)
     )
 }

--- a/test/views/html/incomes/BonusPaymentsAmountSpec.scala
+++ b/test/views/html/incomes/BonusPaymentsAmountSpec.scala
@@ -37,13 +37,12 @@ class BonusPaymentsAmountSpec extends TaiViewSpec with MockitoSugar {
     behave like pageWithCancelLink(Call("GET", controllers.routes.IncomeSourceSummaryController.onPageLoad(id).url))
     behave like pageWithCombinedHeader(
       messages("tai.bonusPaymentsAmount.preHeading", employerName),
-      messages("tai.bonusPaymentsAmount.title",TaxYearRangeUtil.currentTaxYearRangeBetweenDelimited))
+      messages("tai.bonusPaymentsAmount.title",TaxYearRangeUtil.currentTaxYearRangeSingleLineBetweenDelimited))
     behave like pageWithTitle(messages("tai.bonusPaymentsAmount.title", TaxYearRangeUtil.currentTaxYearRangeBetweenDelimited))
     behave like pageWithContinueButtonForm("/check-income-tax/update-income/bonus-overtime-amount")
 
-    "contain hint with static text" in {
-      val hint = doc(view).select("form .form-hint").get(0).text
-      hint mustBe messages("tai.bonusPaymentsAmount.hint")
+    "contain a paragraph with static text" in {
+      doc must haveParagraphWithText(messages("tai.bonusPaymentsAmount.hint"))
     }
 
     "contain an input field with pound symbol appended" in {

--- a/test/views/html/incomes/BonusPaymentsSpec.scala
+++ b/test/views/html/incomes/BonusPaymentsSpec.scala
@@ -39,7 +39,7 @@ class BonusPaymentsSpec extends TaiViewSpec with MockitoSugar with FormValuesCon
     behave like pageWithCancelLink(Call("GET", controllers.routes.IncomeSourceSummaryController.onPageLoad(Id).url))
     behave like pageWithCombinedHeader(
       messages("tai.bonusPayments.preHeading", employerName),
-      messages("tai.bonusPayments.title", TaxYearRangeUtil.currentTaxYearRangeBetweenDelimited))
+      messages("tai.bonusPayments.title", TaxYearRangeUtil.currentTaxYearRangeSingleLineBetweenDelimited))
     behave like pageWithTitle(messages("tai.bonusPayments.title", TaxYearRangeUtil.currentTaxYearRangeBetweenDelimited))
     behave like pageWithContinueButtonForm("/check-income-tax/update-income/bonus-payments")
 


### PR DESCRIPTION
- [x] Unit tests passing
- [x] Coverage reached
- [ ] Acceptance tests passing
- [ ] Reviewed
