### PR TITLE
ST-596-fix: catch exceptions where underpayment has been coded prev y…

### DIFF
--- a/app/uk/gov/hmrc/tai/viewModels/TaxSummaryLabel.scala
+++ b/app/uk/gov/hmrc/tai/viewModels/TaxSummaryLabel.scala
@@ -50,21 +50,22 @@ object TaxSummaryLabel {
 
     lazy val underpaymentAmount = TaxAmountDueFromUnderpayment.amountDue(amount, totalTax)
 
-    taxComponentType match {
-      case UnderPaymentFromPreviousYear =>
-        val href = controllers.routes.UnderpaymentFromPreviousYearController.underpaymentExplanation.url.toString
-        val id = "underPaymentFromPreviousYear"
-        Some(HelpLink(Messages("tai.taxFreeAmount.table.underpaymentFromPreviousYear.link", MonetaryUtil.withPoundPrefix(underpaymentAmount.toInt)), href, id))
+    Try{
+      taxComponentType match {
+        case UnderPaymentFromPreviousYear =>
+          val href = controllers.routes.UnderpaymentFromPreviousYearController.underpaymentExplanation.url.toString
+          val id = "underPaymentFromPreviousYear"
+          Some(HelpLink(Messages("tai.taxFreeAmount.table.underpaymentFromPreviousYear.link", MonetaryUtil.withPoundPrefix(underpaymentAmount.toInt)), href, id))
 
-      case EstimatedTaxYouOweThisYear =>
-        val href = controllers.routes.PotentialUnderpaymentController.potentialUnderpaymentPage.url.toString
-        val id = "estimatedTaxOwedLink"
-        Some(HelpLink(Messages("tai.taxFreeAmount.table.underpaymentFromCurrentYear.link", MonetaryUtil.withPoundPrefix(underpaymentAmount.toInt)), href, id))
+        case EstimatedTaxYouOweThisYear =>
+          val href = controllers.routes.PotentialUnderpaymentController.potentialUnderpaymentPage.url.toString
+          val id = "estimatedTaxOwedLink"
+          Some(HelpLink(Messages("tai.taxFreeAmount.table.underpaymentFromCurrentYear.link", MonetaryUtil.withPoundPrefix(underpaymentAmount.toInt)), href, id))
 
-      case _ =>
-        None
-    }
-
+        case _ =>
+          None
+      }
+    }.getOrElse(None)
   }
 
   private def describe(componentType: TaxComponentType, employmentId: Option[Int], companyCarBenefits: Seq[CompanyCarBenefit], employmentIdNameMap: Map[Int, String])

--- a/test/uk/gov/hmrc/tai/viewModels/TaxSummaryLabelSpec.scala
+++ b/test/uk/gov/hmrc/tai/viewModels/TaxSummaryLabelSpec.scala
@@ -109,5 +109,15 @@ class TaxSummaryLabelSpec extends PlaySpec with FakeTaiPlayApplication {
           actual mustBe TaxSummaryLabel("Estimated tax you owe this year", link)
         }
       }
+
+      "do not show the underpayment explanation link" when {
+        "there are missing incomeCatergories" in {
+          val totalTax : TotalTax = TotalTax(1000, Seq.empty, None, None, None)
+          val taxFreeAmountDetails = TaxFreeAmountDetails(Map.empty, Seq.empty, totalTax)
+
+          val actual = TaxSummaryLabel(UnderPaymentFromPreviousYear, employmentId = None, taxFreeAmountDetails, amount = 1000)
+          actual mustBe TaxSummaryLabel("Underpayment from previous year", None)
+        }
+      }
     }
 }


### PR DESCRIPTION
…r but not current yr

- [x] Unit tests passing
- [x] Coverage reached
- [x] Acceptance tests passing
- [ ] Reviewed
