### PR TITLE
DDCNOS-5081: Change deep linked controllers to make API calls sequentially

### DIFF
--- a/app/controllers/EstimatedIncomeTaxController.scala
+++ b/app/controllers/EstimatedIncomeTaxController.scala
@@ -47,18 +47,13 @@ class EstimatedIncomeTaxController @Inject()(codingComponentService: CodingCompo
   def estimatedIncomeTax(): Action[AnyContent] = (authenticate andThen validatePerson).async {
     implicit request =>
       val nino = request.taiUser.nino
-      val taxSummaryFuture = taxAccountService.taxAccountSummary(nino, TaxYear())
-      val totalTaxFuture = taxAccountService.totalTax(nino, TaxYear())
-      val codingComponentFuture = codingComponentService.taxFreeAmountComponents(nino, TaxYear())
-      val nonTaxCodeIncomeFuture = taxAccountService.nonTaxCodeIncomes(nino, TaxYear())
-      val taxCodeIncomeFuture = taxAccountService.taxCodeIncomes(nino, TaxYear())
 
       for {
-        taxSummary <- taxSummaryFuture
-        codingComponents <- codingComponentFuture
-        totalTax <- totalTaxFuture
-        nonTaxCode <- nonTaxCodeIncomeFuture
-        taxCodeIncomes <- taxCodeIncomeFuture
+        taxSummary <- taxAccountService.taxAccountSummary(nino, TaxYear())
+        codingComponents <- codingComponentService.taxFreeAmountComponents(nino, TaxYear())
+        totalTax <- taxAccountService.totalTax(nino, TaxYear())
+        nonTaxCode <- taxAccountService.nonTaxCodeIncomes(nino, TaxYear())
+        taxCodeIncomes <- taxAccountService.taxCodeIncomes(nino, TaxYear())
         iFormLinks <- partialService.getIncomeTaxPartial
       } yield {
         (taxSummary, totalTax, nonTaxCode, taxCodeIncomes) match {

--- a/app/controllers/IncomeSourceSummaryController.scala
+++ b/app/controllers/IncomeSourceSummaryController.scala
@@ -49,17 +49,12 @@ class IncomeSourceSummaryController @Inject()(val auditConnector: AuditConnector
   def onPageLoad(empId: Int): Action[AnyContent] = (authenticate andThen validatePerson).async {
     implicit request =>
       val nino = request.taiUser.nino
-      
-      val taxCodeIncomesFuture = taxAccountService.taxCodeIncomes(nino, TaxYear())
-      val employmentFuture = employmentService.employment(nino, empId)
-      val benefitsFuture = benefitsService.benefits(nino, TaxYear().year)
-      val estimatedPayCompletionFuture = estimatedPayJourneyCompletionService.hasJourneyCompleted(empId.toString)
 
       (for {
-        taxCodeIncomeDetails <- taxCodeIncomesFuture
-        employmentDetails <- employmentFuture
-        benefitsDetails <- benefitsFuture
-        estimatedPayCompletion <- estimatedPayCompletionFuture
+        taxCodeIncomeDetails <- taxAccountService.taxCodeIncomes(nino, TaxYear())
+        employmentDetails <- employmentService.employment(nino, empId)
+        benefitsDetails <- benefitsService.benefits(nino, TaxYear().year)
+        estimatedPayCompletion <- estimatedPayJourneyCompletionService.hasJourneyCompleted(empId.toString)
       } yield {
         (taxCodeIncomeDetails, employmentDetails) match {
           case (TaiSuccessResponseWithPayload(taxCodeIncomes: Seq[TaxCodeIncome]), Some(employment)) =>

--- a/app/controllers/TaxFreeAmountController.scala
+++ b/app/controllers/TaxFreeAmountController.scala
@@ -46,12 +46,12 @@ class TaxFreeAmountController @Inject()(codingComponentService: CodingComponentS
   def taxFreeAmount: Action[AnyContent] = (authenticate andThen validatePerson).async {
     implicit request =>
       val nino = request.taiUser.nino
-      val totalTaxFuture = taxAccountService.totalTax(nino, TaxYear())
+
       (for {
         codingComponents <- codingComponentService.taxFreeAmountComponents(nino, TaxYear())
         employmentNames <- employmentService.employmentNames(nino, TaxYear())
         companyCarBenefits <- companyCarService.companyCarOnCodingComponents(nino, codingComponents)
-        totalTax <- totalTaxFuture
+        totalTax <- taxAccountService.totalTax(nino, TaxYear())
       } yield {
         totalTax match {
           case TaiSuccessResponseWithPayload(totalTax: TotalTax) =>


### PR DESCRIPTION
- This is a temporary hotfix to alleviate problems with the API being called multiple times when the calls were asynchronous.

- [x] Unit tests passing
- [x] Coverage reached
- [x] Acceptance tests passing
- [ ] Reviewed
