### PR TITLE
data-dynamic attribute removed as it was causing javascript error

### DIFF
--- a/app/views/CanWeContactByPhoneView.scala.html
+++ b/app/views/CanWeContactByPhoneView.scala.html
@@ -46,7 +46,7 @@
     pageHeader = Some(header),
     articleClasses = None) {
 
-    @form(action = Call("POST", viewModel.continueUrl), Symbol("data-dynamic-form") -> "true", Symbol("data-journey-dynamic-radios") -> "") {
+    @form(action = Call("POST", viewModel.continueUrl), Symbol("data-dynamic-form") -> "true") {
 
         <div>
             <p>@Messages("tai.canWeContactByPhone.explanation")</p>

--- a/app/views/benefits/RemoveCompanyBenefitStopDateView.scala.html
+++ b/app/views/benefits/RemoveCompanyBenefitStopDateView.scala.html
@@ -45,7 +45,7 @@ authedUser = Some(user),
 pageHeader = Some(header),
 articleClasses = None){
 
-    @form(action = controllers.benefits.routes.RemoveCompanyBenefitController.submitStopDate(), Symbol("data-dynamic-form") -> "true", Symbol("class") -> "subsection", Symbol("data-journey-dynamic-radios") -> "") {
+    @form(action = controllers.benefits.routes.RemoveCompanyBenefitController.submitStopDate(), Symbol("data-dynamic-form") -> "true", Symbol("class") -> "subsection") {
 
         @{inputRadioGroupStyling(
             stopDateForm(RemoveCompanyBenefitStopDateForm.StopDateChoice),

--- a/app/views/benefits/UpdateOrRemoveCompanyBenefitDecisionView.scala.html
+++ b/app/views/benefits/UpdateOrRemoveCompanyBenefitDecisionView.scala.html
@@ -40,7 +40,7 @@ authedUser = Some(user),
 pageHeader = Some(header),
 articleClasses = None){
 
-    @form(action = controllers.benefits.routes.CompanyBenefitController.submitDecision(), Symbol("data-dynamic-form") -> "true", Symbol("class") -> "subsection", Symbol("data-journey-dynamic-radios") -> "") {
+    @form(action = controllers.benefits.routes.CompanyBenefitController.submitDecision(), Symbol("data-dynamic-form") -> "true", Symbol("class") -> "subsection") {
         @{inputRadioGroupStyling(
             viewModel.decisionForm(UpdateOrRemoveCompanyBenefitDecisionForm.DecisionChoice),
             Seq(

--- a/app/views/employments/AddEmploymentFirstPayFormView.scala.html
+++ b/app/views/employments/AddEmploymentFirstPayFormView.scala.html
@@ -38,7 +38,7 @@ pageHeader = Some(header),
 articleClasses = None
 ) {
 
-    @form(action = controllers.employments.routes.AddEmploymentController.submitFirstPay(), Symbol("data-dynamic-form") -> "true", Symbol("data-journey-dynamic-radios") -> "") {
+    @form(action = controllers.employments.routes.AddEmploymentController.submitFirstPay(), Symbol("data-dynamic-form") -> "true") {
 
         @{inputRadioGroupStyling(
             field=firstPayForm(AddEmploymentFirstPayForm.FirstPayChoice),

--- a/app/views/employments/AddEmploymentPayrollNumberFormView.scala.html
+++ b/app/views/employments/AddEmploymentPayrollNumberFormView.scala.html
@@ -47,7 +47,7 @@
         <li>@Messages("tai.addEmployment.employmentPayrollNumber.bullet4")</li>
     </ul>
 
-    @form(action = controllers.employments.routes.AddEmploymentController.submitEmploymentPayrollNumber(), Symbol("data-dynamic-form") -> "true", Symbol("class") -> "subsection", Symbol("data-journey-dynamic-radios") -> "") {
+    @form(action = controllers.employments.routes.AddEmploymentController.submitEmploymentPayrollNumber(), Symbol("data-dynamic-form") -> "true", Symbol("class") -> "subsection") {
 
         @{inputRadioGroupStyling(
             field=payrollNumberForm(AddEmploymentPayrollNumberForm.PayrollNumberChoice),

--- a/app/views/employments/EndEmploymentIrregularPaymentErrorView.scala.html
+++ b/app/views/employments/EndEmploymentIrregularPaymentErrorView.scala.html
@@ -46,7 +46,7 @@
     <p>@Messages("tai.irregular.para2", model.employerName)</p>
     <p>@Messages("tai.irregular.para3")</p>
 
-    @form(action= controllers.employments.routes.EndEmploymentController.handleIrregularPaymentError(), args = Symbol("data-journey-dynamic-radios") -> "") {
+    @form(action= controllers.employments.routes.EndEmploymentController.handleIrregularPaymentError()) {
 
         @{inputRadioGroupStyling(
             field=irregularPayForm("irregularPayDecision"),

--- a/app/views/employments/UpdateRemoveEmploymentDecisionView.scala.html
+++ b/app/views/employments/UpdateRemoveEmploymentDecisionView.scala.html
@@ -41,7 +41,7 @@
     pageHeader = Some(header),
     articleClasses = None) {
 
-    @form(action = controllers.employments.routes.EndEmploymentController.handleEmploymentUpdateRemove, Symbol("data-journey-dynamic-radios") -> "" ) {
+    @form(action = controllers.employments.routes.EndEmploymentController.handleEmploymentUpdateRemove) {
         <div class="form-group">
 
             @{inputRadioGroupStyling(

--- a/app/views/includes/duplicateSubmissionWarning.scala.html
+++ b/app/views/includes/duplicateSubmissionWarning.scala.html
@@ -26,7 +26,7 @@
 @(duplicateSubmissionWarningForm: Form[YesNoForm], yesChoiceText: String, noChoiceText: String, actionRoute: Call)(implicit request: Request[_], messages: Messages, templateRenderer: uk.gov.hmrc.renderer.TemplateRenderer, ec: scala.concurrent.ExecutionContext)
 
 
-    @form(action = actionRoute, Symbol("data-journey-dynamic-radios") -> "" ) {
+    @form(action = actionRoute) {
         <div class="form-group">
 
             <p>@messages("tai.employment.warning.text1")</p>

--- a/app/views/incomes/DuplicateSubmissionWarningView.scala.html
+++ b/app/views/incomes/DuplicateSubmissionWarningView.scala.html
@@ -41,7 +41,7 @@
     pageHeader = Some(header),
     articleClasses = None) {
 
-    @form(action = controllers.income.estimatedPay.update.routes.IncomeUpdateCalculatorController.submitDuplicateSubmissionWarning, Symbol("data-journey-dynamic-radios") -> "" ) {
+    @form(action = controllers.income.estimatedPay.update.routes.IncomeUpdateCalculatorController.submitDuplicateSubmissionWarning) {
     <div class="form-group">
 
         <p>@viewModel.paragraphOne</p>

--- a/app/views/incomes/nextYear/UpdateIncomeCYPlus1WarningView.scala.html
+++ b/app/views/incomes/nextYear/UpdateIncomeCYPlus1WarningView.scala.html
@@ -41,7 +41,7 @@
     pageHeader = Some(header),
     articleClasses = None) {
 
-    @form(action = controllers.income.routes.UpdateIncomeNextYearController.submitDuplicateWarning(empId), Symbol("data-journey-dynamic-radios") -> "" ) {
+    @form(action = controllers.income.routes.UpdateIncomeNextYearController.submitDuplicateWarning(empId)) {
     <div class="form-group">
 
         <p>@viewModel.paragraphOne</p>

--- a/app/views/incomes/previousYears/UpdateIncomeDetailsDecisionView.scala.html
+++ b/app/views/incomes/previousYears/UpdateIncomeDetailsDecisionView.scala.html
@@ -46,7 +46,7 @@
     <p>@messages("tai.income.previousYears.decision.paragraph.two")</p>
     <p>@messages("tai.income.previousYears.decision.paragraph.three")</p>
 
-    @form(action = controllers.income.previousYears.routes.UpdateIncomeDetailsController.submitDecision(), Symbol("data-dynamic-form") -> "true", Symbol("class") -> "subsection", Symbol("data-journey-dynamic-radios") -> "") {
+    @form(action = controllers.income.previousYears.routes.UpdateIncomeDetailsController.submitDecision(), Symbol("data-dynamic-form") -> "true", Symbol("class") -> "subsection") {
 
         @{inputRadioGroupStyling(
             field=decisionForm(UpdateIncomeDetailsDecisionForm.UpdateIncomeChoice),

--- a/app/views/pensions/AddPensionNumberView.scala.html
+++ b/app/views/pensions/AddPensionNumberView.scala.html
@@ -41,7 +41,7 @@
     articleClasses = None
 ) {
 
-    @form(action = controllers.pensions.routes.AddPensionProviderController.submitPensionNumber(), Symbol("data-dynamic-form") -> "true", Symbol("data-journey-dynamic-radios") -> "") {
+    @form(action = controllers.pensions.routes.AddPensionProviderController.submitPensionNumber(), Symbol("data-dynamic-form") -> "true") {
 
         @{inputRadioGroupStyling(
             field=payrollNumberForm(AddPensionProviderNumberForm.PayrollNumberChoice),

--- a/app/views/pensions/AddPensionReceivedFirstPayView.scala.html
+++ b/app/views/pensions/AddPensionReceivedFirstPayView.scala.html
@@ -38,7 +38,7 @@ ec: scala.concurrent.ExecutionContext)
     articleClasses = None
 ) {
 
-    @form(action = controllers.pensions.routes.AddPensionProviderController.submitFirstPay(), Symbol("data-dynamic-form") -> "true", Symbol("data-journey-dynamic-radios") -> "") {
+    @form(action = controllers.pensions.routes.AddPensionProviderController.submitFirstPay(), Symbol("data-dynamic-form") -> "true") {
 
         @{inputRadioGroupStyling(
             field=firstPayForm(AddPensionProviderFirstPayForm.FirstPayChoice),

--- a/app/views/pensions/update/DoYouGetThisPensionIncomeView.scala.html
+++ b/app/views/pensions/update/DoYouGetThisPensionIncomeView.scala.html
@@ -43,7 +43,7 @@ ec: scala.concurrent.ExecutionContext)
     pageHeader = Some(header),
     articleClasses = None) {
 
-    @form(action = controllers.pensions.routes.UpdatePensionProviderController.handleDoYouGetThisPension, Symbol("data-journey-dynamic-radios") -> "" ) {
+    @form(action = controllers.pensions.routes.UpdatePensionProviderController.handleDoYouGetThisPension) {
         <div class="form-group">
 
             @{inputRadioGroupStyling(


### PR DESCRIPTION
The error was caused in Javascript in Assets frontend. Since there aren't any more updates to Assets frontend we can't fix the Javascript. We dont use Google analytics anymore (GTM instead) and this attribute "data-journey" seems to be about that so I have removed it from tai-frontend.