### PR TITLE
PAYEE-114 changed the pre-heading to return the customer's fullname

### DIFF
--- a/app/controllers/PayeControllerHistoric.scala
+++ b/app/controllers/PayeControllerHistoric.scala
@@ -20,7 +20,6 @@ import controllers.actions.ValidatePerson
 import controllers.auth.{AuthAction, AuthedUser, AuthenticatedRequest}
 import javax.inject.Inject
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
-
 import uk.gov.hmrc.renderer.TemplateRenderer
 import uk.gov.hmrc.tai.config.ApplicationConfig
 import uk.gov.hmrc.tai.model.TaxYear

--- a/app/views/paye/HistoricPayAsYouEarnView.scala.html
+++ b/app/views/paye/HistoricPayAsYouEarnView.scala.html
@@ -46,7 +46,7 @@ messages: Messages, templateRenderer: uk.gov.hmrc.renderer.TemplateRenderer, ec:
 @header = @{
     ptaHeader(
         mainHeadingText = messages("tai.paye.heading", TaxPeriodLabelService.taxPeriodLabel(viewModel.taxYear.year)),
-        preHeadingText = messages("tai.paye.lastTaxYear.preHeading"),
+        preHeadingText = request.fullName,
         displayBackLink = true,
         customBackLinkContent = Some(backLinkToChooseTaxYear))
 }

--- a/conf/messages
+++ b/conf/messages
@@ -844,7 +844,6 @@ tai.paye.incomePension.heading=Your income from private pensions
 tai.paye.lastTaxYear.otherDetailsWrongIform.link=tell us what to change
 tai.paye.lastTaxYear.otherDetailsWrongIform.nextLine=If you cannot contact them or they cannot help then you can {0}
 tai.paye.lastTaxYear.otherDetailsWrongIform=If there is an income from an employer or pension provider missing or wrong please contact them first. Ask them to send the right details to HMRC.
-tai.paye.lastTaxYear.preHeading=Previous tax years
 tai.paye.lastTaxYear.table.headingOne=Income source
 tai.paye.lastTaxYear.table.headingTwo=Income
 tai.paye.lastTaxYear.table.link=Check the income details sent to us

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -846,7 +846,6 @@ tai.paye.incomePension.heading=Eich incwm o bensiynau preifat
 tai.paye.lastTaxYear.otherDetailsWrongIform.link=rhowch wybod i ni beth i’w newid
 tai.paye.lastTaxYear.otherDetailsWrongIform.nextLine=Os na allwch gysylltu â nhw neu os na allant helpu, gallwch {0}
 tai.paye.lastTaxYear.otherDetailsWrongIform=Os yw incwm gan gyflogwr neu ddarparwr pensiwn ar goll neu’n anghywir, cysylltwch â nhw yn y lle cyntaf. Gofynnwch iddynt anfon y manylion cywir i CThEM.
-tai.paye.lastTaxYear.preHeading=Blynyddoedd treth blaenorol
 tai.paye.lastTaxYear.table.headingOne=Ffynhonnell incwm
 tai.paye.lastTaxYear.table.headingTwo=Incwm
 tai.paye.lastTaxYear.table.link=Gwiriwch y manylion incwm a anfonwyd atom

--- a/test/views/html/paye/HistoricPayAsYouEarnViewSpec.scala
+++ b/test/views/html/paye/HistoricPayAsYouEarnViewSpec.scala
@@ -47,7 +47,7 @@ class HistoricPayAsYouEarnViewSpec extends TaiViewSpec {
   "historicPayAsYouEarn view" should {
 
     behave like pageWithCombinedHeader(
-      messages("tai.paye.lastTaxYear.preHeading"),
+      authRequest.fullName,
       messages("tai.paye.heading", TaxPeriodLabelService.taxPeriodLabel(cyMinusOneTaxYear.year)))
 
     behave like pageWithTitle(
@@ -57,7 +57,7 @@ class HistoricPayAsYouEarnViewSpec extends TaiViewSpec {
       val taxYear = cyMinusOneTaxYear
       val newDoc = doc(view)
 
-      newDoc.body.text must include(messages("tai.paye.lastTaxYear.preHeading"))
+      newDoc.body.text must include(authRequest.fullName)
       newDoc.body.text must include(messages("tai.paye.heading", TaxPeriodLabelService.taxPeriodLabel(taxYear.year)))
     }
 


### PR DESCRIPTION
**JIRA**
[PAYEE-114](https://jira.tools.tax.service.gov.uk/browse/PAYEE-114)
**WHAT**
We changed the pre-heading to return the customer's full name in the current and previous tax years employment summary page.
**WHY**
Stakeholders have raised a request to add the name onto the page as a lot of customers use this as their employment history as it give a summary of all employers during the year rather than an individual breakdown for that specific employer

- [x] Unit tests passing
- [x] Coverage reached
- [ ] Acceptance tests passing
- [ ] Reviewed
