### PR TITLE
Revert "DDCNL-9685: Remove custom backlink component and JS"

### DIFF
--- a/app/assets/javascripts/backlink.js
+++ b/app/assets/javascripts/backlink.js
@@ -1,0 +1,31 @@
+/* global $ */
+// =====================================================
+// Back link mimics browser back functionality
+// =====================================================
+// store referrer value to cater for IE - https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/10474810/  */
+var docReferrer = document.referrer;
+// prevent resubmit warning
+if (
+    window.history &&
+    window.history.replaceState &&
+    typeof window.history.replaceState === 'function'
+) {
+    window.history.replaceState(null, null, window.location.href);
+}
+// back click handle, dependent upon presence of referrer & no host change
+const backlink = document.getElementById('back-link');
+
+if(backlink != null && backlink != 'undefined') {
+    backlink.addEventListener('click', function (e) {
+        e.preventDefault();
+        if (
+            window.history &&
+            window.history.back &&
+            typeof window.history.back === 'function' &&
+            docReferrer !== '' &&
+            docReferrer.indexOf(window.location.host) !== -1
+        ) {
+            window.history.back();
+        }
+    });
+}

--- a/app/views/includes/backLink.scala.html
+++ b/app/views/includes/backLink.scala.html
@@ -1,0 +1,28 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@()(implicit messages: Messages)
+
+
+
+<p class="govuk-!-margin-bottom-0">
+    @includes.link(
+        id=Some("backLink"),
+        copy=messages("tai.back-link.upper"),
+        url = "#",
+        linkClasses=Seq("link-back js-visible")
+    )
+</p>


### PR DESCRIPTION
Reverts hmrc/tai-frontend#1337 due to spike of 404s after deployment.