### PR TITLE
DDCNL-11659: Fix - Display "Income Tax refund" when API returns negative value in income-tax-history cards

### DIFF
--- a/app/controllers/IncomeTaxHistoryController.scala
+++ b/app/controllers/IncomeTaxHistoryController.scala
@@ -82,7 +82,7 @@ class IncomeTaxHistoryController @Inject() (
           // a failure is treated as no payment instead of marking the value as temporary not available
           val maybeLastPayment: Option[Payment] = lastPaymentForEmployment(accounts, employment.sequenceNumber)
 
-          val isPension = maybeTaxCode.exists(_.componentType == PensionIncome)
+          val isPension      = maybeTaxCode.exists(_.componentType == PensionIncome)
           val maybeTaxAmount = maybeLastPayment.map(_.taxAmountYearToDate)
 
           IncomeTaxHistoryViewModel(

--- a/app/controllers/IncomeTaxHistoryController.scala
+++ b/app/controllers/IncomeTaxHistoryController.scala
@@ -83,6 +83,7 @@ class IncomeTaxHistoryController @Inject() (
           val maybeLastPayment: Option[Payment] = lastPaymentForEmployment(accounts, employment.sequenceNumber)
 
           val isPension = maybeTaxCode.exists(_.componentType == PensionIncome)
+          val maybeTaxAmount = maybeLastPayment.map(_.taxAmountYearToDate)
 
           IncomeTaxHistoryViewModel(
             employerName = employment.name,
@@ -94,9 +95,10 @@ class IncomeTaxHistoryController @Inject() (
             maybeTaxableIncome = maybeLastPayment.map { payment =>
               withPoundPrefix(MoneyPounds(payment.amountYearToDate))
             },
-            maybeIncomeTaxPaid = maybeLastPayment.map { payment =>
-              withPoundPrefix(MoneyPounds(payment.taxAmountYearToDate))
+            maybeIncomeTaxPaid = maybeTaxAmount.map { amount =>
+              withPoundPrefix(MoneyPounds(amount))
             },
+            isIncomeTaxRefund = maybeTaxAmount.exists(_ < 0),
             maybeTaxCode = maybeTaxCode.map(_.taxCode)
           )
         }.toList

--- a/app/uk/gov/hmrc/tai/viewModels/incomeTaxHistory/IncomeTaxHistoryViewModel.scala
+++ b/app/uk/gov/hmrc/tai/viewModels/incomeTaxHistory/IncomeTaxHistoryViewModel.scala
@@ -27,5 +27,6 @@ case class IncomeTaxHistoryViewModel(
   maybeEndDate: Option[LocalDate],
   maybeTaxableIncome: Option[String],
   maybeIncomeTaxPaid: Option[String],
+  isIncomeTaxRefund: Boolean,
   maybeTaxCode: Option[String]
 )

--- a/app/views/incomeTaxHistory/IncomeTaxHistoryView.scala.html
+++ b/app/views/incomeTaxHistory/IncomeTaxHistoryView.scala.html
@@ -162,7 +162,11 @@ messages: Messages)
                                 @if(summary.maybeIncomeTaxPaid.isDefined) {
                                     <div class="govuk-summary-list__row">
                                         <dt class="govuk-summary-list__key">
-                                            @Messages("tai.incomeTax.history.incomeTaxPaid")
+                                            @if(summary.isIncomeTaxRefund) {
+                                                @Messages("tai.incomeTax.history.incomeTaxRefund")
+                                            } else {
+                                                @Messages("tai.incomeTax.history.incomeTaxPaid")
+                                            }
                                         </dt>
                                         <dd class="govuk-summary-list__value">
                                             @summary.maybeIncomeTaxPaid

--- a/conf/messages
+++ b/conf/messages
@@ -651,6 +651,7 @@ tai.incomeTax.history.startDate = Start date
 tai.incomeTax.history.endDate = End date
 tai.incomeTax.history.taxableIncome = Taxable income
 tai.incomeTax.history.incomeTaxPaid = Income Tax paid
+tai.incomeTax.history.incomeTaxRefund = Income Tax refund
 tai.incomeTax.history.taxCode = Tax code
 tai.incomeTax.history.unavailable = Currently unavailable
 tai.incomeTax.history.endDate.notApplicable = Not applicable

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -651,6 +651,7 @@ tai.incomeTax.history.startDate = Dyddiad dechrau
 tai.incomeTax.history.endDate = Dyddiad dod i ben
 tai.incomeTax.history.taxableIncome = Incwm trethadwy
 tai.incomeTax.history.incomeTaxPaid = Treth Incwm a dalwyd
+tai.incomeTax.history.incomeTaxRefund = Ad-daliad Treth Incwm
 tai.incomeTax.history.taxCode = Cod treth
 tai.incomeTax.history.unavailable = Ddim ar gael ar hyn o bryd
 tai.incomeTax.history.endDate.notApplicable = ddim yn gymwys

--- a/test/controllers/IncomeTaxHistoryControllerSpec.scala
+++ b/test/controllers/IncomeTaxHistoryControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,12 +30,13 @@ import play.api.test.Helpers.{contentAsString, defaultAwaitTimeout, status}
 import uk.gov.hmrc.http.UpstreamErrorResponse
 import uk.gov.hmrc.tai.model.TaxYear
 import uk.gov.hmrc.tai.viewModels.incomeTaxHistory.IncomeTaxYear
-import uk.gov.hmrc.tai.model.domain.{AnnualAccount, Employment}
+import uk.gov.hmrc.tai.model.domain.{AnnualAccount, Available, Employment, Monthly, Payment}
 import uk.gov.hmrc.tai.service.{EmploymentService, RtiService, TaxAccountService}
 import uk.gov.hmrc.tai.util.viewHelpers.JsoupMatchers
 import utils.{AuthenticatedRequestFixture, BaseSpec, TaxAccountSummaryTestData}
 import views.html.incomeTaxHistory.IncomeTaxHistoryView
 
+import java.time.LocalDate
 import scala.concurrent.Future
 
 class IncomeTaxHistoryControllerSpec extends BaseSpec with TaxAccountSummaryTestData with JsoupMatchers {
@@ -250,6 +251,85 @@ class IncomeTaxHistoryControllerSpec extends BaseSpec with TaxAccountSummaryTest
         .getOrElse(IncomeTaxYear(TaxYear(1), List.empty))
         .map(_.incomeTaxHistory.map(_.maybeTaxCode))
         .futureValue mustBe List(Some(taxCodeIncome.taxCode))
+    }
+
+    "set IncomeTaxHistoryViewModel.isIncomeTaxRefund to true" when {
+      "taxAmountYearToDate is negative value" in {
+        val taxAmountYearToDate = BigDecimal(-187)
+        val latestPayment       =
+          Payment(LocalDate.now.minusWeeks(1), BigDecimal(1000), taxAmountYearToDate, 0, 100, 10, 5, Monthly)
+
+        val annualAccount = AnnualAccount(empEmployment1.sequenceNumber, TaxYear(), Available, Seq(latestPayment), Nil)
+
+        when(rtiService.getAllPaymentsForYear(any(), any())(any()))
+          .thenReturn(EitherT.rightT[Future, UpstreamErrorResponse](Seq(annualAccount)))
+
+        when(taxAccountService.taxCodeIncomes(any(), any())(any()))
+          .thenReturn(Future.successful(Right(Seq(taxCodeIncome))))
+
+        when(employmentService.employments(any(), any())(any()))
+          .thenReturn(EitherT.rightT[Future, UpstreamErrorResponse](Seq(empEmployment1)))
+
+        val controller = new TestController
+        val result     = controller.getIncomeTaxYear(nino, TaxYear())(authRequest)
+
+        result
+          .getOrElse(IncomeTaxYear(TaxYear(1), List.empty))
+          .map(_.incomeTaxHistory.head.isIncomeTaxRefund)
+          .futureValue mustBe true
+      }
+    }
+
+    "set IncomeTaxHistoryViewModel.isIncomeTaxRefund to false" when {
+      "taxAmountYearToDate is zero" in {
+        val taxAmountYearToDate = BigDecimal(0)
+        val latestPayment       =
+          Payment(LocalDate.now.minusWeeks(1), BigDecimal(1000), taxAmountYearToDate, 0, 100, 10, 5, Monthly)
+
+        val annualAccount = AnnualAccount(empEmployment1.sequenceNumber, TaxYear(), Available, Seq(latestPayment), Nil)
+
+        when(rtiService.getAllPaymentsForYear(any(), any())(any()))
+          .thenReturn(EitherT.rightT[Future, UpstreamErrorResponse](Seq(annualAccount)))
+
+        when(taxAccountService.taxCodeIncomes(any(), any())(any()))
+          .thenReturn(Future.successful(Right(Seq(taxCodeIncome))))
+
+        when(employmentService.employments(any(), any())(any()))
+          .thenReturn(EitherT.rightT[Future, UpstreamErrorResponse](Seq(empEmployment1)))
+
+        val controller = new TestController
+        val result     = controller.getIncomeTaxYear(nino, TaxYear())(authRequest)
+
+        result
+          .getOrElse(IncomeTaxYear(TaxYear(1), List.empty))
+          .map(_.incomeTaxHistory.head.isIncomeTaxRefund)
+          .futureValue mustBe false
+      }
+
+      "taxAmountYearToDate is positive value" in {
+        val taxAmountYearToDate = BigDecimal(150)
+        val latestPayment       =
+          Payment(LocalDate.now.minusWeeks(1), BigDecimal(1000), taxAmountYearToDate, 0, 100, 10, 5, Monthly)
+
+        val annualAccount = AnnualAccount(empEmployment1.sequenceNumber, TaxYear(), Available, Seq(latestPayment), Nil)
+
+        when(rtiService.getAllPaymentsForYear(any(), any())(any()))
+          .thenReturn(EitherT.rightT[Future, UpstreamErrorResponse](Seq(annualAccount)))
+
+        when(taxAccountService.taxCodeIncomes(any(), any())(any()))
+          .thenReturn(Future.successful(Right(Seq(taxCodeIncome))))
+
+        when(employmentService.employments(any(), any())(any()))
+          .thenReturn(EitherT.rightT[Future, UpstreamErrorResponse](Seq(empEmployment1)))
+
+        val controller = new TestController
+        val result     = controller.getIncomeTaxYear(nino, TaxYear())(authRequest)
+
+        result
+          .getOrElse(IncomeTaxYear(TaxYear(1), List.empty))
+          .map(_.incomeTaxHistory.head.isIncomeTaxRefund)
+          .futureValue mustBe false
+      }
     }
   }
 }

--- a/test/views/html/incomeTaxHistory/IncomeTaxHistoryViewSpec.scala
+++ b/test/views/html/incomeTaxHistory/IncomeTaxHistoryViewSpec.scala
@@ -278,7 +278,7 @@ class IncomeTaxHistoryViewSpec extends TaiViewSpec {
       val doc  = Jsoup.parse(html.toString())
 
       doc.text() must include(messages("tai.incomeTax.history.incomeTaxRefund"))
-      doc.html() must not include "&minus;"
+      doc.text() must not include "&minus;"
     }
 
   }

--- a/test/views/html/incomeTaxHistory/IncomeTaxHistoryViewSpec.scala
+++ b/test/views/html/incomeTaxHistory/IncomeTaxHistoryViewSpec.scala
@@ -229,15 +229,14 @@ class IncomeTaxHistoryViewSpec extends TaiViewSpec {
     "display Income Tax refund label when isIncomeTaxRefund is true" in {
 
       val model = historyViewModel.copy(
-        maybeIncomeTaxPaid = Some("£187"),
+        maybeIncomeTaxPaid = Some("£150"),
         isIncomeTaxRefund = true
       )
 
       val html = incomeTaxHistoryView(person, List(IncomeTaxYear(taxYear, List(model))))
       val doc  = Jsoup.parse(html.toString())
 
-      doc.text() must include(messages("tai.incomeTax.history.incomeTaxRefund"))
-      doc.text() must include("£187")
+      doc must haveDivItemWithText("Income Tax refund £150")
     }
 
     "display Income Tax paid label when isIncomeTaxRefund is false" in {
@@ -250,7 +249,7 @@ class IncomeTaxHistoryViewSpec extends TaiViewSpec {
       val html = incomeTaxHistoryView(person, List(IncomeTaxYear(taxYear, List(model))))
       val doc  = Jsoup.parse(html.toString())
 
-      doc.text() must include(messages("tai.incomeTax.history.incomeTaxPaid"))
+      doc must haveDivItemWithText("Income Tax paid £100")
     }
 
     "display Income Tax paid label with 0 when amount is zero" in {
@@ -263,8 +262,7 @@ class IncomeTaxHistoryViewSpec extends TaiViewSpec {
       val html = incomeTaxHistoryView(person, List(IncomeTaxYear(taxYear, List(model))))
       val doc  = Jsoup.parse(html.toString())
 
-      doc.text() must include(messages("tai.incomeTax.history.incomeTaxPaid"))
-      doc.text() must include("£0")
+      doc must haveDivItemWithText("Income Tax paid £0")
     }
 
     "not display minus sign for income tax values" in {
@@ -277,7 +275,7 @@ class IncomeTaxHistoryViewSpec extends TaiViewSpec {
       val html = incomeTaxHistoryView(person, List(IncomeTaxYear(taxYear, List(model))))
       val doc  = Jsoup.parse(html.toString())
 
-      doc.text() must include(messages("tai.incomeTax.history.incomeTaxRefund"))
+      doc        must haveDivItemWithText("Income Tax refund £187")
       doc.text() must not include "&minus;"
     }
 

--- a/test/views/html/incomeTaxHistory/IncomeTaxHistoryViewSpec.scala
+++ b/test/views/html/incomeTaxHistory/IncomeTaxHistoryViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ class IncomeTaxHistoryViewSpec extends TaiViewSpec {
     None,
     Some("taxableIncome"),
     Some("incomeTaxPaid"),
+    isIncomeTaxRefund = false,
     Some(s"taxCode-${taxYear.start}")
   )
 
@@ -51,6 +52,7 @@ class IncomeTaxHistoryViewSpec extends TaiViewSpec {
     Some(taxYear.end.minusYears(1)),
     Some("taxableIncome"),
     Some("incomeTaxPaid"),
+    isIncomeTaxRefund = false,
     Some(s"taxCode-${taxYear.start}")
   )
 
@@ -63,6 +65,7 @@ class IncomeTaxHistoryViewSpec extends TaiViewSpec {
     Some(taxYear.end.minusYears(2)),
     Some("taxableIncome"),
     Some("incomeTaxPaid"),
+    isIncomeTaxRefund = false,
     None
   )
 
@@ -75,6 +78,7 @@ class IncomeTaxHistoryViewSpec extends TaiViewSpec {
     Some(taxYear.end.minusYears(3)),
     Some("taxableIncome"),
     Some("incomeTaxPaid"),
+    isIncomeTaxRefund = false,
     None
   )
 
@@ -87,6 +91,7 @@ class IncomeTaxHistoryViewSpec extends TaiViewSpec {
     Some(taxYear.end.minusYears(4)),
     Some("taxableIncome"),
     Some("incomeTaxPaid"),
+    isIncomeTaxRefund = false,
     Some(s"taxCode-${taxYear.start}")
   )
 
@@ -99,6 +104,7 @@ class IncomeTaxHistoryViewSpec extends TaiViewSpec {
     Some(taxYear.end.minusYears(5)),
     Some("taxableIncome"),
     Some("incomeTaxPaid"),
+    isIncomeTaxRefund = false,
     Some(s"taxCode-${taxYear.start}")
   )
 
@@ -218,6 +224,61 @@ class IncomeTaxHistoryViewSpec extends TaiViewSpec {
             doc must haveDivItemWithText("Tax code " + messages("tai.incomeTax.history.unavailable"))
         }
       }
+    }
+
+    "display Income Tax refund label when isIncomeTaxRefund is true" in {
+
+      val model = historyViewModel.copy(
+        maybeIncomeTaxPaid = Some("£187"),
+        isIncomeTaxRefund = true
+      )
+
+      val html = incomeTaxHistoryView(person, List(IncomeTaxYear(taxYear, List(model))))
+      val doc  = Jsoup.parse(html.toString())
+
+      doc.text() must include(messages("tai.incomeTax.history.incomeTaxRefund"))
+      doc.text() must include("£187")
+    }
+
+    "display Income Tax paid label when isIncomeTaxRefund is false" in {
+
+      val model = historyViewModel.copy(
+        maybeIncomeTaxPaid = Some("£100"),
+        isIncomeTaxRefund = false
+      )
+
+      val html = incomeTaxHistoryView(person, List(IncomeTaxYear(taxYear, List(model))))
+      val doc  = Jsoup.parse(html.toString())
+
+      doc.text() must include(messages("tai.incomeTax.history.incomeTaxPaid"))
+    }
+
+    "display Income Tax paid label with 0 when amount is zero" in {
+
+      val model = historyViewModel.copy(
+        maybeIncomeTaxPaid = Some("£0"),
+        isIncomeTaxRefund = false
+      )
+
+      val html = incomeTaxHistoryView(person, List(IncomeTaxYear(taxYear, List(model))))
+      val doc  = Jsoup.parse(html.toString())
+
+      doc.text() must include(messages("tai.incomeTax.history.incomeTaxPaid"))
+      doc.text() must include("£0")
+    }
+
+    "not display minus sign for income tax values" in {
+
+      val model = historyViewModel.copy(
+        maybeIncomeTaxPaid = Some("£187"),
+        isIncomeTaxRefund = true
+      )
+
+      val html = incomeTaxHistoryView(person, List(IncomeTaxYear(taxYear, List(model))))
+      val doc  = Jsoup.parse(html.toString())
+
+      doc.text() must include(messages("tai.incomeTax.history.incomeTaxRefund"))
+      doc.html() must not include "&minus;"
     }
 
   }


### PR DESCRIPTION
- [ ] Unit tests passing
- [ ] Coverage reached
- [ ] Acceptance tests passing
- [ ] Reviewed
